### PR TITLE
Wagtail 6.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.5.1,<6.0
+Sphinx>>=7.1.2
 sphinx-rtd-theme
 -e .

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'wagtail>=5.2',
     ],
     extras_require={
-        'testing': ['jinja2>=2.10,<3.0', 'markupsafe==2.0.1']
+        'testing': ['jinja2>=2.10,<4.0', 'markupsafe==2.1.5']
     },
     zip_safe=False,
     license='BSD License',

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Framework :: Django',
-        'Framework :: Django :: 3',
-        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5',

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -1,7 +1,6 @@
 from django.db import models
 
 from wagtail.admin.panels import FieldPanel
-from wagtail.admin.panels import FieldPanel as ImageChooserPanel
 from wagtail.contrib.settings.models import register_setting
 from wagtail.models import Page
 
@@ -45,7 +44,7 @@ class PersonPage(PageLDMixin, Page):
     content_panels = Page.content_panels + [
         FieldPanel('bio'),
         FieldPanel('date_of_birth'),
-        ImageChooserPanel('photo'),
+        FieldPanel('photo'),
     ]
 
     def ld_entity(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{38,39,310}-dj32-wt52
-    py{38,39,310,311}-dj42-wt{52,60}
-    py{311,312}-dj50-wt{52,60}
+	py{38,39,310,311}-dj42-wt{52,60,61}
+    py{310,311,312}-dj50-wt{52,60,61}
 	flake8,isort,docs
 
 [gh-actions]
@@ -24,12 +23,12 @@ pip_pre = True
 
 deps =
 	{[base]deps}
-	dj32: django>=3.2,<4.0
 	dj42: django>=4.2,<4.3
 	dj50: django>=5.0,<5.1
 	djHEAD: django
 	wt52: Wagtail>=5.2,<5.3
 	wt60: Wagtail>=6.0,<6.1
+	wt61: Wagtail>=6.1,<6.2
 	wtHEAD: Wagtail
 
 [testenv:flake8]


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

## Wagtail 6.1 upgrade

<details>
<summary>Code review check list</summary>

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>